### PR TITLE
Add brand filter as client-side filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ temp/
 .idea/
 .DS_store
 out
+.vscode

--- a/assets/styles/tabs.scss
+++ b/assets/styles/tabs.scss
@@ -51,6 +51,10 @@
         }
     }
 
+    .brand {
+        margin-top: 8px;
+    }
+
     .search-input {
         margin-left: 48px;
         display: inline-flex;

--- a/components/ImageCard.tsx
+++ b/components/ImageCard.tsx
@@ -17,15 +17,7 @@ const getDayDifference = (date: any) => moment(date).diff(moment(), 'days');
 
 function ImageCard(props: ImageCardProps): JSX.Element {
     const { keycapset } = props;
-    const {
-        name,
-        coverImageUrl,
-        type,
-        slug,
-        groupbuyStartDate,
-        groupbuyEndDate,
-        isInterestCheck,
-    } = keycapset;
+    const { name, coverImageUrl, type, slug, groupbuyStartDate, groupbuyEndDate, isInterestCheck } = keycapset;
 
     const state = useContext<InititalState>(Context);
     const isInFuture: boolean = moment().diff(groupbuyStartDate, 'days') < 0;
@@ -44,8 +36,7 @@ function ImageCard(props: ImageCardProps): JSX.Element {
                     <div className="image">
                         <img
                             src={
-                                coverImageUrl === undefined ||
-                                coverImageUrl === ''
+                                coverImageUrl === undefined || coverImageUrl === ''
                                     ? '/images/empty-base-kit-illu.svg'
                                     : coverImageUrl
                             }
@@ -64,9 +55,7 @@ function ImageCard(props: ImageCardProps): JSX.Element {
                                 <span className="small">{type}</span>
                                 {name || 'Title goes here'}
                             </h4>
-                            <p className="light">
-                                {moment(groupbuyStartDate).format('YYYY')}
-                            </p>
+                            <p className="light">{moment(groupbuyStartDate).format('YYYY')}</p>
                         </div>
 
                         <div className="bottom">
@@ -77,25 +66,16 @@ function ImageCard(props: ImageCardProps): JSX.Element {
                                     <>
                                         {isInFuture ? (
                                             <>
-                                                Starting in
-                                                <span className="bold">
-                                                    {getDayDifference(
-                                                        groupbuyStartDate
-                                                    )}
-                                                </span>
-                                                days
+                                                Starting in{' '}
+                                                <span className="bold">{getDayDifference(groupbuyStartDate)}</span> days
                                             </>
                                         ) : (
                                             <>
-                                                {getDayDifference(
-                                                    groupbuyEndDate
-                                                ) > 0 ? (
+                                                {getDayDifference(groupbuyEndDate) > 0 ? (
                                                     <>
                                                         Ending in
                                                         <span className="bold">
-                                                            {getDayDifference(
-                                                                groupbuyEndDate
-                                                            )}
+                                                            {getDayDifference(groupbuyEndDate)}
                                                         </span>
                                                         days
                                                     </>
@@ -107,10 +87,7 @@ function ImageCard(props: ImageCardProps): JSX.Element {
                                     </>
                                 )}
                             </p>
-                            <ButtonLink
-                                href="/[type]/[set]"
-                                as={`/${type}/${slug}`}
-                            >
+                            <ButtonLink href="/[type]/[set]" as={`/${type}/${slug}`}>
                                 View this set
                             </ButtonLink>
                         </div>

--- a/components/Multiselect.tsx
+++ b/components/Multiselect.tsx
@@ -5,24 +5,17 @@ import Select from 'react-select';
  * https://react-select.com
  */
 
-interface MultiSelectProps {
-    value?: any[];
-    options: any[];
+interface MultiSelectProps<T> {
+    value?: T[];
+    options: T[];
     onChange: Function;
     isMulti?: boolean;
     label: String;
-    defaultValue?: any;
+    defaultValue?: T;
 }
 
-function MultiSelect(props: MultiSelectProps): JSX.Element {
-    const {
-        value,
-        options,
-        onChange,
-        isMulti,
-        label,
-        defaultValue,
-    }: MultiSelectProps = props;
+function MultiSelect<T>(props: MultiSelectProps<T>): JSX.Element {
+    const { value, options, onChange, isMulti, label, defaultValue }: MultiSelectProps<T> = props;
 
     const SELECT_STYLES = {
         control: (base: any) => ({
@@ -48,7 +41,7 @@ function MultiSelect(props: MultiSelectProps): JSX.Element {
                 options={options}
                 isMulti={isMulti}
                 isSearchable
-                defaultValue={defaultValue || options[0]}
+                defaultValue={isMulti ? defaultValue : defaultValue || options[0]}
             />
         </div>
     );

--- a/components/Tabs/Tab.tsx
+++ b/components/Tabs/Tab.tsx
@@ -1,43 +1,29 @@
 import React, { useContext } from 'react';
-import Button from '../Button';
 import Context from '../../context';
-import { AVAILABILITY_FILTER, CAP_FILTER } from '../../constants';
+import Button from '../Button';
 
 interface TabProps {
     id: String;
     type: 'cap' | 'availability';
 }
 
+const stateFilterKeys = {
+    cap: 'activeTab',
+    availability: 'availabilityFilter',
+};
+
 function Tab(props: TabProps): JSX.Element {
     const { id, type } = props;
-    const {
-        setGlobalState,
-        filters: { activeTab, availabilityFilter },
-    } = useContext(Context);
+    const { setGlobalState, filters } = useContext(Context);
+    const typeKey = stateFilterKeys[type];
 
     function handleUpdateFilters(): void {
-        if (type === 'cap') {
-            if (isActive) {
-                setGlobalState({
-                    filters: { availabilityFilter, activeTab: 'all' },
-                });
-            } else {
-                setGlobalState({
-                    filters: { availabilityFilter, activeTab: id },
-                });
-            }
-        } else if (isActive) {
-            setGlobalState({
-                filters: { activeTab, availabilityFilter: 'none' },
-            });
-        } else {
-            setGlobalState({
-                filters: { activeTab, availabilityFilter: id },
-            });
-        }
+        setGlobalState({
+            filters: { ...filters, [typeKey]: id === filters[typeKey] ? 'none' : id },
+        });
     }
 
-    const isActive = id === activeTab || id === availabilityFilter;
+    const isActive = id === filters[typeKey];
     return (
         <li className="tab">
             <Button

--- a/components/Tabs/index.tsx
+++ b/components/Tabs/index.tsx
@@ -1,10 +1,10 @@
 import React, { useContext } from 'react';
 import { InititalState } from 'typings';
-
-import Tab from './Tab';
+import { AVAILABILITY_FILTER } from '../../constants';
 import Context from '../../context';
+import MultiSelect from '../Multiselect';
 import Select from '../Select';
-import { AVAILABILITY_FILTER, CAP_FILTER } from '../../constants';
+import Tab from './Tab';
 
 interface TabsProps {}
 
@@ -17,6 +17,7 @@ function Tabs(props: TabsProps): JSX.Element {
             filters: {
                 ...state.filters,
                 availabilityFilter: 'none',
+                brandFilter: [],
             },
         });
     }
@@ -49,45 +50,56 @@ function Tabs(props: TabsProps): JSX.Element {
                     />
                 </div> */}
 
-                <div className="tabs">
-                    <label className="label">Filter availability</label>
-                    <ul>
-                        {state.availability.map((tab: String, idx: number) => (
-                            <Tab
-                                type={AVAILABILITY_FILTER}
-                                id={tab}
-                                key={idx}
-                            />
-                        ))}
-                        <li>
-                            {state.filters.availabilityFilter !== 'none' && (
-                                <p
-                                    className="small light clickable"
-                                    onClick={resetFilter}
-                                >
-                                    reset
-                                </p>
-                            )}
-                        </li>
-                    </ul>
-                </div>
-                <div className="select">
-                    <Select
-                        label="Filter caps by availability"
-                        name="Choose availability"
-                        onSelectChange={(selectedFilterValue) =>
-                            state.setGlobalState({
-                                filters: {
-                                    ...state.filters,
-                                    availabilityFilter: selectedFilterValue,
-                                },
-                            })
-                        }
-                        values={state.availability.map((t) => ({
-                            id: t,
-                            name: t,
-                        }))}
-                    />
+                <div>
+                    <div className="tabs">
+                        <label className="label">Filter availability</label>
+                        <ul>
+                            {state.availability.map((tab: String, idx: number) => (
+                                <Tab type={AVAILABILITY_FILTER} id={tab} key={idx} />
+                            ))}
+                            <li>
+                                {state.filters.availabilityFilter !== 'none' && (
+                                    <p className="small light clickable" onClick={resetFilter}>
+                                        reset
+                                    </p>
+                                )}
+                            </li>
+                        </ul>
+                    </div>
+                    <div className="select">
+                        <Select
+                            label="Filter caps by availability"
+                            name="Choose availability"
+                            onSelectChange={(selectedFilterValue) =>
+                                state.setGlobalState({
+                                    filters: {
+                                        ...state.filters,
+                                        availabilityFilter: selectedFilterValue,
+                                    },
+                                })
+                            }
+                            values={state.availability.map((t) => ({
+                                id: t,
+                                name: t,
+                            }))}
+                        />
+                    </div>
+
+                    <div className="brand">
+                        <MultiSelect
+                            isMulti={true}
+                            label="Filter brands"
+                            options={state.brand}
+                            onChange={(values) => {
+                                state.setGlobalState({
+                                    filters: {
+                                        ...state.filters,
+                                        brandFilter: (values || []).map((brand) => brand.value),
+                                    },
+                                });
+                            }}
+                        />
+                    </div>
                 </div>
 
                 <div className="counter">

--- a/constants.ts
+++ b/constants.ts
@@ -9,7 +9,7 @@ export const BRAND_OPTIONS = [
     { value: 'maxkey', label: 'MaxKey' },
     { value: 'zfrontier', label: 'zFrontier' },
     { value: 'leopold', label: 'Leopold' },
-    { value: 'ducky', labele: 'Ducky' },
+    { value: 'ducky', label: 'Ducky' },
 ];
 
 export const MATERIAL_OPTIONS = [
@@ -34,24 +34,10 @@ export const INTEREST_CHECK = 'ic';
 export const WAITING_FOR_GROUPBUY = 'waiting';
 export const IN_GROUP_BUY = 'gb';
 export const ENDED = 'ended';
-export const AVAILABILITY = [
-    INTEREST_CHECK,
-    WAITING_FOR_GROUPBUY,
-    IN_GROUP_BUY,
-    ENDED,
-];
+export const AVAILABILITY = [INTEREST_CHECK, WAITING_FOR_GROUPBUY, IN_GROUP_BUY, ENDED];
 
-export const TABS = [
-    'all',
-    'gmk',
-    'pbt',
-    'sa',
-    'dsa',
-    'kat',
-    'jtk',
-    'kam',
-    'dcs',
-];
+export const TABS = ['all', 'gmk', 'pbt', 'sa', 'dsa', 'kat', 'jtk', 'kam', 'dcs'];
 
 export const AVAILABILITY_FILTER = 'availability';
+export const BRAND_FILTER = 'brand';
 export const CAP_FILTER = 'cap';

--- a/context.ts
+++ b/context.ts
@@ -2,7 +2,7 @@ import { createContext } from 'react';
 import moment from 'moment';
 import { InititalState, Filters, Keycapset } from 'typings';
 
-import { AVAILABILITY, TABS } from './constants';
+import { AVAILABILITY, TABS, BRAND_OPTIONS } from './constants';
 import { getDayDifference } from './components/StatusLabel';
 import { INTEREST_CHECK, WAITING_FOR_GROUPBUY, IN_GROUP_BUY, ENDED } from './constants';
 
@@ -30,10 +30,27 @@ function filterByAvailability(set: Keycapset, availabilityFilter: string): boole
     }
 }
 
+function filterByBrand(set: Keycapset, brandFilter: string[] = []): boolean {
+    return brandFilter.length === 0 || brandFilter.includes(set.brand);
+}
+
 function handleFilters(keycapset: Keycapset, filters: Filters): boolean {
-    if (filters.activeTab === 'all' && filters.availabilityFilter === 'none') return true;
-    if (filters.activeTab === 'all') return filterByAvailability(keycapset, filters.availabilityFilter);
-    return keycapset.type === filters.activeTab && filterByAvailability(keycapset, filters.availabilityFilter);
+    // This part is just an old way of filtering, should be dismissed
+    if (filters.activeTab !== 'all' && keycapset.type !== filters.activeTab) {
+        return false;
+    }
+
+    // Check for availability filter
+    if (!filterByAvailability(keycapset, filters.availabilityFilter)) {
+        return false;
+    }
+
+    // Check for brand filter
+    if (!filterByBrand(keycapset, filters.brandFilter)) {
+        return false;
+    }
+
+    return true;
 }
 
 export function reduceState(state, obj) {
@@ -54,9 +71,11 @@ export const INITITAL_STATE: InititalState = {
     filters: {
         activeTab: 'all',
         availabilityFilter: 'none',
+        brandFilter: [],
     },
     tabs: TABS,
     availability: AVAILABILITY,
+    brand: BRAND_OPTIONS,
     keycapsets: [],
     filteredSets: [],
     searchQuery: '',

--- a/queries/index.ts
+++ b/queries/index.ts
@@ -1,17 +1,13 @@
 import { gql } from 'apollo-boost';
 
 const FETCH_KEYCAPSET_QUERY = gql`
-    query FETCH_KEYCAPSET_QUERY(
-        $limit: Int
-        $offset: Int
-        $type: String
-        $query: String
-    ) {
+    query FETCH_KEYCAPSET_QUERY($limit: Int, $offset: Int, $type: String, $query: String) {
         allKeycapsetsCount
         keycapsets(limit: $limit, offset: $offset, type: $type, query: $query) {
             _id
             name
             type
+            brand
             coverImageUrl
             slug
             groupbuyStartDate
@@ -75,13 +71,7 @@ const CREATE_VENDOR_MUTATION = gql`
         $socials: [String]
         $url: String
     ) {
-        createVendor(
-            name: $name
-            country: $country
-            logoUrl: $logoUrl
-            socials: $socials
-            url: $url
-        ) {
+        createVendor(name: $name, country: $country, logoUrl: $logoUrl, socials: $socials, url: $url) {
             name
             _id
         }

--- a/types/interfaces.d.ts
+++ b/types/interfaces.d.ts
@@ -22,6 +22,11 @@ declare module 'typings' {
         isInterestCheck: boolean;
     }
 
+    interface Brand {
+        value: string;
+        label: string;
+    }
+
     interface Vendor {
         _id?: string;
         socials?: string[];
@@ -37,12 +42,14 @@ declare module 'typings' {
     interface Filters {
         activeTab: string;
         availabilityFilter: string;
+        brandFilter: string[];
     }
 
     interface InititalState {
         filters: Filters;
         tabs: string[];
         availability: string[];
+        brand: Brand[];
         keycapsets: Keycapset[];
         filteredSets: Keycapset[];
         searchQuery: string;


### PR DESCRIPTION
Brand filter has been added as a client-side filter.
UI is still to improve (there are no spaces between filters).
Anyway, all the filtering work should be done server-side performing a graphql query for every filter changed.

In this PR there are also a few of small corrections.