### PR TITLE
Fix: Favoriting no longer changes scroll position

### DIFF
--- a/assets/styles/image-card.scss
+++ b/assets/styles/image-card.scss
@@ -4,7 +4,6 @@
     overflow: hidden;
     box-shadow: 0px 1px 2px rgba(0, 16, 75, 0.2);
     transition: 120ms cubic-bezier(0.445, 0.05, 0.55, 0.95);
-    cursor: pointer;
 
     // &:hover {
     //     transform: scale(1.007);
@@ -29,6 +28,7 @@
             height: 100%;
             width: 100%;
             object-fit: cover;
+            cursor: pointer;
         }
 
         .logo {
@@ -75,6 +75,7 @@
 
             .heart-icon {
                 display: inline-flex;
+                cursor: pointer;
 
                 .heart-fill {
                     visibility: hidden;

--- a/components/ImageCard.tsx
+++ b/components/ImageCard.tsx
@@ -69,9 +69,9 @@ function ImageCard(props: ImageCardProps): JSX.Element {
 
     return (
         <LazyLoad offset={400} height={400}>
-            <Link href="/set/[set]" as={`/set/${slug}`} prefetch>
-                <div className={`image-card ${isTemplate ? 'disabled' : ''}`}>
-                    <div className="image">
+            <div className={`image-card ${isTemplate ? 'disabled' : ''}`}>
+                <div className="image">
+                    <Link href="/set/[set]" as={`/set/${slug}`} prefetch>
                         <img
                             className="set"
                             src={
@@ -80,45 +80,45 @@ function ImageCard(props: ImageCardProps): JSX.Element {
                                     : coverImageUrl
                             }
                         />
+                    </Link>
+                </div>
+
+                <div className="details">
+                    <div className="top">
+                        <h4 className="set-title">
+                            <Link href="/set/[set]" as={`/set/${slug}`} prefetch>
+                                {name || 'Title goes here'}
+                            </Link>
+                        </h4>
+                        <StatusLabel
+                            groupbuyStartDate={groupbuyStartDate}
+                            groupbuyEndDate={groupbuyEndDate}
+                            isIc={isInterestCheck}
+                        />
                     </div>
 
-                    <div className="details">
-                        <div className="top">
-                            <h4 className="set-title">{name || 'Title goes here'}</h4>
-                            <StatusLabel
-                                groupbuyStartDate={groupbuyStartDate}
-                                groupbuyEndDate={groupbuyEndDate}
-                                isIc={isInterestCheck}
-                            />
-                        </div>
-
-                        <div className="bottom">
-                            <span className="bold">
-                                <span>
-                                    {getLabelByBrand(brand)} {type && type.toUpperCase()}
-                                </span>
-                                <span>{moment(groupbuyStartDate).format('YYYY')}</span>
-                            </span>
-
+                    <div className="bottom">
+                        <span className="bold">
                             <span>
-                                <span
-                                    data-tip="Sign up to create collections"
-                                    onClick={userWantSet}
-                                    className="heart-icon"
-                                >
-                                    <HeartIcon
-                                        filled={state.userWants.includes(keycapset._id)}
-                                        isDisabled={!state.isLoggedIn}
-                                    />
-                                    {!state.isLoggedIn && (
-                                        <ReactTooltip delayHide={500} className="tooltip" effect="solid" />
-                                    )}
-                                </span>
+                                {getLabelByBrand(brand)} {type && type.toUpperCase()}
                             </span>
-                        </div>
+                            <span>{moment(groupbuyStartDate).format('YYYY')}</span>
+                        </span>
+
+                        <span>
+                            <span data-tip="Sign up to create collections" onClick={userWantSet} className="heart-icon">
+                                <HeartIcon
+                                    filled={state.userWants.includes(keycapset._id)}
+                                    isDisabled={!state.isLoggedIn}
+                                />
+                                {!state.isLoggedIn && (
+                                    <ReactTooltip delayHide={500} className="tooltip" effect="solid" />
+                                )}
+                            </span>
+                        </span>
                     </div>
                 </div>
-            </Link>
+            </div>
         </LazyLoad>
     );
 }


### PR DESCRIPTION
By wrapping the entire contents of ImageCard inside a `<Link />` instance, click events from that conflicted with those on the favorite button.