### PR TITLE
Update button-link.scss

### DIFF
--- a/assets/styles/button-link.scss
+++ b/assets/styles/button-link.scss
@@ -1,6 +1,6 @@
 .button-link {
     font-size: 14px;
-    color: #539bfb;
+    color: var(--blue);
     border-bottom: 2px solid #d4e4fa;
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
changed the value in `color:` to read from `:root` in `variables.scss`
old version used the hex value directly, however to reduce complexity of future color changes it would be best to use `color: var(--blue)`
this does not interfere with `a {color: inherit;}
the issue presented itself when using dark mode. the links for geekhack forum threads were not changing color from black and made it difficult to read. this also provides a change to the about section links in text.