### PR TITLE
Update Meta.tsx to include key attibutes

### DIFF
--- a/components/Meta.tsx
+++ b/components/Meta.tsx
@@ -39,21 +39,35 @@ function Meta(props: MetaProps) {
             />
             <link rel="icon" href="/images/favicon.ico" type="image/x-icon" />
             <meta name="author" content="noudadrichem" />
-            <meta property="og:title" content={title || TITLE} />
-            <meta name="twitter:title" content={title || TITLE} />
+            <meta key="meta_og_title" property="og:title" content={title || TITLE} />
+            <meta key="meta_twitter_title" name="twitter:title" content={title || TITLE} />
 
-            <meta name="description" content={description || DESCRIPTION} />
             <meta
+                key="meta_description"
+                name="description"
+                content={description || DESCRIPTION}
+            />
+            <meta 
+                key="meta_og_description"
                 property="og:description"
                 content={description || DESCRIPTION}
             />
             <meta
+                key="meta_twitter_description"
                 name="twitter:description"
                 content={description || DESCRIPTION}
             />
 
-            <meta property="og:image" content={metaImgUrl || META_IMG_URL} />
-            <meta name="twitter:image" content={metaImgUrl || META_IMG_URL} />
+            <meta
+                key="meta_og_image"
+                property="og:image"
+                content={metaImgUrl || META_IMG_URL}
+            />
+            <meta
+                key="meta_twitter_image"
+                name="twitter:image"
+                content={metaImgUrl || META_IMG_URL}
+            />
 
             {/* <!-- Global site tag (gtag.js) - Google Analytics --> */}
             <script


### PR DESCRIPTION
Adding key attribute to meta descriptions inside of <Head/> will stop duplicates.
This fixes the issue of linking /set/[someid] not showing the correct preview title or image like intended.

Explanation of fix can be found here https://github.com/vercel/next.js/issues/6919#issuecomment-487374749