### PR TITLE
Remove sign up dropdown text selection

### DIFF
--- a/assets/styles/nav.scss
+++ b/assets/styles/nav.scss
@@ -104,7 +104,7 @@
                 }
 
                 .btn-sign-up {
-                    user-select: all;
+                    user-select: none;
                     position: relative;
                     padding-left: 32px;
                     padding-right: 32px;


### PR DESCRIPTION
Prevents selecting the text of the button and the dropdown when clicking on it.

Picture of the issue:

![image](https://user-images.githubusercontent.com/7083755/90338428-e9bbe280-dfe9-11ea-9f51-7a48adfdb935.png)
